### PR TITLE
Small but important installation errata in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,15 @@ instance to the database.
 
 ### Installation
 
+```
 pip install genologics
+```
 
 or for the cutting edge version:
 
-pip install http://github.com/scilifelab/
+```
+pip install https://github.com/SciLifeLab/genologics/tarball/master
+```
 
 ### Usage
 


### PR DESCRIPTION
Only tarballs are pip-installable, not github repos.
