### PR TITLE
Changes for API v2

### DIFF
--- a/examples/get_projects.py
+++ b/examples/get_projects.py
@@ -44,10 +44,6 @@ for key, value in udt.items():
         value = codecs.encode(value, 'UTF-8')
     print ' ', key, '=', value
 
-print '    notes:'
-for note in project.notes:
-    print note.uri, note.content
-
 print '    files:'
 for file in project.files:
     print file.id

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -13,27 +13,33 @@ import time
 from xml.etree import ElementTree
 
 _NSMAP = dict(
-    artgr='http://genologics.com/ri/artifactgroup',
     art='http://genologics.com/ri/artifact',
+    artgr='http://genologics.com/ri/artifactgroup',
     cnf='http://genologics.com/ri/configuration',
     con='http://genologics.com/ri/container',
     ctp='http://genologics.com/ri/containertype',
     exc='http://genologics.com/ri/exception',
     file='http://genologics.com/ri/file',
+    inst='http://genologics.com/ri/instrument',
     lab='http://genologics.com/ri/lab',
-    perm='http://genologics.com/ri/permissions',
     prc='http://genologics.com/ri/process',
     prj='http://genologics.com/ri/project',
     prop='http://genologics.com/ri/property',
+    protcnf='http://genologics.com/ri/protocolconfiguration',
+    protstepcnf='http://genologics.com/ri/stepconfiguration',
     prx='http://genologics.com/ri/processexecution',
+    ptm='http://genologics.com/ri/processtemplate',
     ptp='http://genologics.com/ri/processtype',
     res='http://genologics.com/ri/researcher',
-    rgt='http://genologics.com/ri/reagent',
     ri='http://genologics.com/ri',
+    rt='http://genologics.com/ri/routing',
     rtp='http://genologics.com/ri/reagenttype',
     smp='http://genologics.com/ri/sample',
+    stg='http://genologics.com/ri/stage',
+    stp='http://genologics.com/ri/step',
     udf='http://genologics.com/ri/userdefined',
-    ver='http://genologics.com/ri/version')
+    ver='http://genologics.com/ri/version',
+    wkfcnf='http://genologics.com/ri/workflowconfiguration')
 
 for prefix, uri in _NSMAP.iteritems():
     ElementTree._namespace_map[uri] = prefix
@@ -555,7 +561,6 @@ class Project(Entity):
     researcher    = EntityDescriptor('researcher', Researcher)
     udf           = UdfDictionaryDescriptor()
     udt           = UdtDictionaryDescriptor()
-    notes         = EntityListDescriptor('note', Note)
     files         = EntityListDescriptor(nsmap('file:file'), File)
     externalids   = ExternalidListDescriptor()
     # permissions XXX


### PR DESCRIPTION
These are the changes for API v2:
- Posting of artifactgroups has been removed
- Notes on projects have been removed
- Reagent endpoint has been removed
- Permissions endpoint has been removed

Basically I just refactored the namespace map dictionary adding missing endpoints and removing old ones. I also removed the _notes_ attribute from project, and fixed the corresponding example.

@pekrau, would be nice if you can take a look at this pull request before it is merged :-)

Tack!
