### PR TITLE
Modified the error handling to catch non-xml errors, like privilege-related ones.

### DIFF
--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -88,16 +88,21 @@ class Lims(object):
         """Parse the XML returned in the response.
         Raise an HTTP error if the response status is not 200.
         """
-        root = ElementTree.fromstring(response.content)
         if response.status_code != 200:
-            node = root.find('message')
-            if node is None:
-                response.raise_for_status()
-            message = "%s: %s" % (response.status_code, node.text)
-            node = root.find('suggested-actions')
-            if node is not None:
-                message += ' ' + node.text
+            try:
+                root = ElementTree.fromstring(response.content)
+                node = root.find('message')
+                if node is None:
+                    response.raise_for_status()
+                message = "%s: %s" % (response.status_code, node.text)
+                node = root.find('suggested-actions')
+                if node is not None:
+                    message += ' ' + node.text
+            except ElementTree.ParseError: # some error messages might not follow the xml standard
+                message=response.content 
             raise requests.exceptions.HTTPError(message)
+        else:
+            root = ElementTree.fromstring(response.content)
         return root
 
     def get_udfs(self, name = None, attach_to_name = None, attach_to_category = None, start_index = None):


### PR DESCRIPTION
The error I got from trying to access the API with an unsufficient privileged account was an XML parsing error, which was a bit uninformative, so this should help spotting errors, in case the error message fails to be parsed properly
