### PR TITLE
added Unfound node handling for EntityDescriptors

### DIFF
--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -369,7 +369,10 @@ class EntityDescriptor(TagDescriptor):
     def __get__(self, instance, cls):
         instance.get()
         node = instance.root.find(self.tag)
-        return self.klass(instance.lims, uri=node.attrib['uri'])
+        if node is None:
+            return None
+        else:
+            return self.klass(instance.lims, uri=node.attrib['uri'])
 
 
 class EntityListDescriptor(EntityDescriptor):


### PR DESCRIPTION
This should be useful whenever someone tries to get a non-existing  parent process from an artifact, like the first artifact in a tree. It will get a None object, rather than an error.
