### PR TITLE
Add version to genologics.config and as argument to genologics.lims()

### DIFF
--- a/genologics/config.py
+++ b/genologics/config.py
@@ -20,6 +20,11 @@ except:
 	warnings.warn("Please make sure you've created your own Genologics configuration file (i.e: ~/.genologicsrc) as stated in README.md")
 	sys.exit(-1)
 
+if config.has_section('genologics') and config.has_option('genologics','VERSION'):
+	VERSION = config.get('genologics', 'VERSION').rstrip()
+else:
+	VERSION = 'v2'
+	
 if config.has_section('logging') and config.has_option('logging','MAIN_LOG'):
 	MAIN_LOG = config.get('logging', 'MAIN_LOG').rstrip()
 else:

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -24,7 +24,7 @@ class Lims(object):
 
     VERSION = 'v2'
 
-    def __init__(self, baseuri, username, password):
+    def __init__(self, baseuri, username, password, version = VERSION):
         """baseuri: Base URI for the GenoLogics server, excluding
                     the 'api' or version parts!
                     For example: https://genologics.scilifelab.se:8443/
@@ -34,6 +34,7 @@ class Lims(object):
         self.baseuri = baseuri.rstrip('/') + '/'
         self.username = username
         self.password = password
+        self.VERSION = version
         self.cache = dict()
         # For optimization purposes, enables requests to persist connections
         self.request_session = requests.Session()

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -30,6 +30,7 @@ class Lims(object):
                     For example: https://genologics.scilifelab.se:8443/
         username: The account name of the user to login as.
         password: The password for the user account to login as.
+        version: The optional LIMS API version, by default 'v2' 
         """
         self.baseuri = baseuri.rstrip('/') + '/'
         self.username = username


### PR DESCRIPTION
Adding version to the genologics.config and adding version as an optional argument to genologics.lims, users may have be able to simplify coding on platforms with different LIMS installs.  We have 'v1' for Geneus on our current servers, but will soon add a new server running 'v2' for Clarity.  The proposed modification will default to the version specified as genologics.lims.VERSION so it will seamlessly integrate with current installs and configurations that do not specify the version.


    from genologics.config import BASEURI,USERNAME,PASSWORD, VERSION
    lims = Lims(BASEURI,USERNAME,PASSWORD, VERSION)
