### PR TITLE
resolve

### DIFF
--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -591,6 +591,10 @@ class EntityListDescriptor(EntityDescriptor):
         result = []
         for node in instance.root.findall(self.tag):
             result.append(self.klass(instance.lims, uri=node.attrib['uri']))
+
+        if self.tag == 'sample' and len(result) > 1:
+            instance.lims.get_batch(result)
+            
         return result
 
 

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -108,7 +108,7 @@ class SampleHistory:
         and creates an entry like this : output -> (process, input)"""
         samp_art_map ={}
         if self.sample_name:
-            artifacts = self.lims.get_artifacts(sample_name = self.sample_name, type = 'Analyte') 
+            artifacts = self.lims.get_artifacts(sample_name = self.sample_name, type = 'Analyte', resolve=True) 
             for one_art in artifacts:
                 input_arts = one_art.input_artifact_list()
                 for input_art in input_arts:
@@ -126,7 +126,7 @@ class SampleHistory:
         history = {}
         hist_list = []
        #getting the list of all expected analytes.
-        artifacts = self.lims.get_artifacts(sample_name = self.sample_name, type = 'Analyte')
+        artifacts = self.lims.get_artifacts(sample_name = self.sample_name, type = 'Analyte', resolve=True)
         processes=[]
         inputs=[]
         if in_art:
@@ -676,6 +676,7 @@ class Entity(object):
                 raise ValueError("Entity uri and id can't be both None")
             else:
                 uri = lims.get_uri(cls._URI, id)
+
         try:
             return lims.cache[uri]
         except KeyError:
@@ -897,7 +898,7 @@ class Process(Entity):
                     ins.append(inp)
         return ins
     
-    def all_inputs(self,unique=True):
+    def all_inputs(self,unique=True, resolve=True):
         """Retrieving all input artifacts from input_output_maps
         if unique is true, no duplicates are returned.
         """
@@ -909,9 +910,12 @@ class Process(Entity):
             raise TypeError
         if unique:
             ids = list(frozenset(ids))
-        return [Artifact(self.lims,id=id) for id in ids if id is not None]
+        if resolve:
+            return self.lims.get_batch([Artifact(self.lims,id=id) for id in ids if id is not None])
+        else:
+            return [Artifact(self.lims,id=id) for id in ids if id is not None]
 
-    def all_outputs(self,unique=True):
+    def all_outputs(self,unique=True, resolve=True):
         """Retrieving all output artifacts from input_output_maps
         if unique is true, no duplicates are returned.
         """
@@ -919,7 +923,10 @@ class Process(Entity):
         ids = [io[1]['limsid'] for io in self.input_output_maps if io[1] is not None]
         if unique:
             ids = list(frozenset(ids))
-        return  [Artifact(self.lims,id=id) for id in ids if id is not None]
+        if resolve:
+            return  self.lims.get_batch([Artifact(self.lims,id=id) for id in ids if id is not None])
+        else:
+            return  [Artifact(self.lims,id=id) for id in ids if id is not None]
 
     def shared_result_files(self):
         """Retreve all resultfiles of output-generation-type PerAllInputs."""

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -250,7 +250,8 @@ class Lims(object):
                       artifact_flag_name=None, working_flag=None, qc_flag=None,
                       sample_name=None, samplelimsid=None, artifactgroup=None, containername=None,
                       containerlimsid=None, reagent_label=None,
-                      udf=dict(), udtname=None, udt=dict(), start_index=None):
+                      udf=dict(), udtname=None, udt=dict(), start_index=None,
+                      resolve=False):
         """Get a list of artifacts, filtered by keyword arguments.
         name: Artifact name, or list of names.
         type: Artifact type, or list of types.
@@ -284,7 +285,10 @@ class Lims(object):
                                   reagent_label=reagent_label,
                                   start_index=start_index)
         params.update(self._get_params_udf(udf=udf, udtname=udtname, udt=udt))
-        return self._get_instances(Artifact, params=params)
+        if resolve:
+            return self.get_batch(self._get_instances(Artifact, params=params))
+        else:
+            return self._get_instances(Artifact, params=params)
 
     def get_containers(self, name=None, type=None,
                        state=None, last_modified=None,

--- a/scripts/undemultiplexed_index.py
+++ b/scripts/undemultiplexed_index.py
@@ -338,7 +338,7 @@ class LaneQC():
                 self.exp_lane_clust = 18000000
             else:                               
                 self.exp_lane_clust = 10000000
-        elif self.run_type == 'HiSeq Rapid Flow Cell v1' or self.run_type == "TruSeq Rapid Flow Cell v2" or self.run_type == "TruSeq Rapid Flow Cell v1":
+        elif self.run_type in ['HiSeq Rapid Flow Cell v1','HiSeq Rapid Flow Cell v2', "TruSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v1"] :
             self.exp_lane_clust = 114000000
         elif self.run_type == 'HiSeq Flow Cell v3':
             self.exp_lane_clust = 143000000


### PR DESCRIPTION
So this will turn off lazy loading when you call process.all_inputs() or process.all_outputs(), and resolve them with a batch call instead of resolving them one after the other. 

This also allows to use batch calls for lims.get_artifacts, through the argument 'resolve'. Default is false, but you can use True to force a batch call for all artifacts.