### PR TITLE
Reagent labels 2

### DIFF
--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -871,9 +871,6 @@ class Researcher(Entity):
     def name(self):
         return u"%s %s" % (self.first_name, self.last_name)
 
-class Reagent_label(Entity):
-    """Reagent label element"""
-    reagent_label = StringDescriptor('reagent-label')
 
 class Note(Entity):
     "Note attached to a project or a sample."

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -1183,18 +1183,19 @@ class ReagentType(Entity):
     _URI="reagenttypes"
     _TAG="reagent-type"
 
+    name    =StringAttributeDescriptor('name')
     category=StringDescriptor('reagent-category')
 
-    def __init__(self, lims, uri=None, id=None):
-        super(ReagentType, self).__init__(lims,uri,id)
-        assert self.uri is not None
-        self.root=lims.get(self.uri)
-        self.sequence=None
-        for t in self.root.findall('special-type'):
+    @property
+    def sequence(self):
+        self.get()
+        for t in self.root.findall("special-type"):
             if t.attrib.get("name") == "Index":
                 for child in t.findall("attribute"):
                     if child.attrib.get("name") == "Sequence":
-                        self.sequence=child.attrib.get("value")
+                        return child.attrib.get("value")
+        return None
+
 
 Sample.artifact          = EntityDescriptor('artifact', Artifact)
 StepActions.step         = EntityDescriptor('step', Step)

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -10,6 +10,7 @@ import re
 import urlparse
 import datetime
 import time
+from collections import MutableSet
 from xml.etree import ElementTree
 import logging
 


### PR DESCRIPTION
Three commits:
- First: moves the access to the index sequence of a ReagentType object into a property, so it supports lazy fetching.
 - Second: uses a custom set class to represent the reagent labels of an Artifact, so it's now possible to add and remove reagent labels. Since this changes the container for reagent labels from a list to a set, I added a __getitem__ method to support numeric indexing, for compatibility.
- Third: removed the Reagent_label class which I believe is provably not being used anymore