### PR TITLE
Batch calls

### DIFF
--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -388,14 +388,14 @@ class Lims(object):
         root = ElementTree.Element(nsmap('ri:links'))
         klass = None
         result = []
-        needs_request=False
+        needs_request=[]
         for instance in instances:
             if not klass:
                 klass = instance.__class__
             if force or instance.root is None:
                 ElementTree.SubElement(root, 'link', dict(uri=instance.uri,
                                                   rel=klass._URI))
-                needs_request=True
+                needs_request.append(instance.uri)
             else:
                 result.append(instance)
 
@@ -403,8 +403,8 @@ class Lims(object):
             uri = self.get_uri(klass._URI, 'batch/retrieve')
             data = self.tostring(ElementTree.ElementTree(root))
             root = self.post(uri, data)
-            for node in root.getchildren():
-                instance = klass(self, uri=node.attrib['uri'])
+            for node, uri in zip(root.getchildren(), needs_request):
+                instance = klass(self, uri=uri)
                 instance.root = node
                 result.append(instance)
         return result

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -97,7 +97,7 @@ class Lims(object):
                           auth=(self.username, self.password),
                           headers={'content-type': 'application/xml',
                                    'accept': 'application/xml'})
-        return self.parse_response(r)
+        return self.parse_response(r, success_status = [200, 201, 202])
 
     def check_version(self):
         """Raise ValueError if the version for this interface
@@ -112,11 +112,11 @@ class Lims(object):
             if node.attrib['major'] == self.VERSION: return
         raise ValueError('version mismatch')
 
-    def parse_response(self, response):
+    def parse_response(self, response, success_status = [200]):
         """Parse the XML returned in the response.
         Raise an HTTP error if the response status is not 200.
         """
-        if response.status_code != 200:
+        if not response.status_code in success_status:
             try:
                 root = ElementTree.fromstring(response.content)
                 node = root.find('message')

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -11,6 +11,7 @@ __all__ = ['Lab', 'Researcher', 'Project', 'Sample',
            'Artifact', 'Lims']
 
 import itertools
+import re
 import urllib
 from cStringIO import StringIO
 

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -408,6 +408,27 @@ class Lims(object):
                 result.append(instance)
         return result
 
+    def put_batch(self, instances):
+        """Update multiple instances using a single batch request."""
+
+        if not instances:
+            return
+
+        inst_iter = iter(instances)
+        first = next(inst_iter)
+        klass = first.__class__
+        # Tag is art:details, con:details, etc.
+        example_root = first.root
+        ns_uri = re.match("{(.*)}.*", example_root.tag).group(1)
+        root = ElementTree.Element("{%s}details" % (ns_uri))
+        root.append(first.root)
+        for instance in inst_iter:
+            root.append(instance.root)
+
+        uri = self.get_uri(klass._URI, 'batch/update')
+        data = self.tostring(ElementTree.ElementTree(root))
+        root = self.post(uri, data)
+
     def tostring(self, etree):
         "Return the ElementTree contents as a UTF-8 encoded XML string."
         outfile = StringIO()

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -10,6 +10,7 @@ __all__ = ['Lab', 'Researcher', 'Project', 'Sample',
            'Containertype', 'Container', 'Processtype', 'Process',
            'Artifact', 'Lims']
 
+import itertools
 import urllib
 from cStringIO import StringIO
 


### PR DESCRIPTION
Description of commits:

-    Support more "success" status codes. For example, the batch POST call (in the fourth commit) returns HTTP 202.
-    Make some changes to get_batch (commits 2 and 3):
  -     It now supports any collection type as input, not just list
  -     It also supports a force parameter, to make it fetch all instances no matter if they're cached or not. This is similar to the force in Entity.get()
  -     The check for whether it is cached is changed to "instance.root is None". The previous method detected entities which were instantiated (i.e. the entity existed) but hadn't yet fetched the XML (get()) as cached.
-  Last 2 commits: a batch update call


Update: Couldn't resist to improve the code a bit, it's functionally equivalent though