### PR TITLE
add test for getting and setting Step in placements

### DIFF
--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -1119,11 +1119,15 @@ class StepPlacements(Entity):
                 input = Artifact(self.lims, uri=node.attrib['uri'])
                 location=(None, None)
                 if node.find('location'):
-                    location = (Container(self.lims, uri=node.find('location').find('container').attrib['uri']), node.find('location').find('value').text)
+                    location = (
+                        Container( self.lims, uri=node.find('location').find('container').attrib['uri']),
+                        node.find('location').find('value').text
+                    )
                 self._placementslist.append([input, location])
         return self._placementslist
 
     def set_placement_list(self, value):
+        self.get_placement_list()
         for node in self.root.find('output-placements').findall('output-placement'):
             for pair in value:
                 art=pair[0]

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -6,7 +6,7 @@ from io import BytesIO
 from genologics.lims import Lims
 from genologics.entities import StringDescriptor, StringAttributeDescriptor, StringListDescriptor, \
     StringDictionaryDescriptor, IntegerDescriptor, BooleanDescriptor, UdfDictionary, StepActions, Researcher, Artifact, \
-    Step
+    Step, StepPlacements, Container
 
 if version_info.major == 2:
     from mock import patch, Mock
@@ -236,6 +236,10 @@ class TestEntities(TestCase):
     def setUp(self):
         self.lims = Lims(self.url, username='test', password='password')
 
+    def _tostring(self, entity):
+        return self.lims.tostring(ElementTree.ElementTree(entity.root)).decode("utf-8")
+
+
 class TestStepActions(TestEntities):
     url = 'http://testgenologics.com:4040'
     step_actions_xml = """<stp:actions xmlns:stp="http://genologics.com/ri/step" uri="...">
@@ -309,3 +313,65 @@ class TestStepActions(TestEntities):
                                       'step': step1, 'rework-step': step2}]
             assert s.next_actions == expected_next_actions
 
+
+class TestStepPlacements(TestEntities):
+    url = 'http://testgenologics.com:4040'
+    generic_step_placements_xml = """<?xml version='1.0' encoding='utf-8'?>
+<stp:placements xmlns:stp="http://genologics.com/ri/step" uri="{url}/steps/s1/placements">
+  <step uri="{url}/steps/s1" />
+  <configuration uri="{url}/configuration/protocols/1/steps/1">Step name</configuration>
+  <selected-containers>
+    <container uri="{url}/containers/{container}" />
+  </selected-containers>
+  <output-placements>
+    <output-placement uri="{url}/artifacts/a1">
+      <location>
+        <container limsid="{container}" uri="{url}/containers/{container}" />
+        <value>{loc1}</value>
+      </location>
+    </output-placement>
+    <output-placement uri="{url}/artifacts/a2">
+      <location>
+        <container limsid="{container}" uri="{url}/containers/{container}" />
+        <value>{loc2}</value>
+      </location>
+    </output-placement>
+  </output-placements>
+</stp:placements>"""
+    original_step_placements_xml = generic_step_placements_xml.format(url=url, container="c1", loc1='1:1', loc2='2:1')
+    modloc_step_placements_xml = generic_step_placements_xml.format(url=url, container="c1", loc1='3:1', loc2='4:1')
+    modcont_step_placements_xml = generic_step_placements_xml.format(url=url, container="c2", loc1='1:1', loc2='1:1')
+
+
+
+    def test_get_plactements_list(self):
+        s = StepPlacements(uri=self.lims.get_uri('steps', 's1', 'placements'), lims=self.lims)
+        with patch('requests.Session.get',return_value=Mock(content = self.original_step_placements_xml, status_code=200)):
+            a1 = Artifact(uri='http://testgenologics.com:4040/artifacts/a1', lims=self.lims)
+            a2 = Artifact(uri='http://testgenologics.com:4040/artifacts/a2', lims=self.lims)
+            c1 = Container(uri='http://testgenologics.com:4040/containers/c1', lims=self.lims)
+            expected_placements = [[a1,(c1,'1:1')], [a2,(c1,'2:1')]]
+            assert s.get_placement_list() == expected_placements
+
+    def test_set_plactements_list(self):
+        a1 = Artifact(uri='http://testgenologics.com:4040/artifacts/a1', lims=self.lims)
+        a2 = Artifact(uri='http://testgenologics.com:4040/artifacts/a2', lims=self.lims)
+        c1 = Container(uri='http://testgenologics.com:4040/containers/c1', lims=self.lims)
+        c2 = Container(uri='http://testgenologics.com:4040/containers/c2', lims=self.lims)
+
+        s = StepPlacements(uri=self.lims.get_uri('steps', 's1', 'placements'), lims=self.lims)
+        with patch('requests.Session.get',return_value=Mock(content = self.original_step_placements_xml, status_code=200)):
+            new_placements = [[a1,(c1,'3:1')], [a2,(c1,'4:1')]]
+            s.set_placement_list(new_placements)
+            assert self._tostring(s) == self.modloc_step_placements_xml
+
+    def test_set_plactements_list_fail(self):
+        a1 = Artifact(uri='http://testgenologics.com:4040/artifacts/a1', lims=self.lims)
+        a2 = Artifact(uri='http://testgenologics.com:4040/artifacts/a2', lims=self.lims)
+        c2 = Container(uri='http://testgenologics.com:4040/containers/c2', lims=self.lims)
+
+        s = StepPlacements(uri=self.lims.get_uri('steps', 's1', 'placements'), lims=self.lims)
+        with patch('requests.Session.get',return_value=Mock(content = self.original_step_placements_xml, status_code=200)):
+            new_placements = [[a1,(c2,'1:1')], [a2,(c2,'1:1')]]
+            s.set_placement_list(new_placements)
+            assert self._tostring(s) == self.modcont_step_placements_xml


### PR DESCRIPTION
Step placements seems to work fine with python3.
I've added a few tests for it and the last test fails at the moment and it's expected.

few comments/questions:
- The set_placement_list function seems to assume that get_placement_list has been called once before. Can this be safely assumed? (note that I changed this for the purpose of the test)
- set_placement_list only modify existing output-placement: ie it needs to exist and the artifact is not changed and no new one can be added. 
-  when set_placement_list changes the container (and it can). It does not update the selected-containers entry (see failing test)
- If we're not reading/using the selected-containers, is it worth adding a property in Step so you can get the placement list directly 
```python
step.placements_list
```
instead of 
```python
step.placements.placement_list
```
Apologies if some/all these questions are daft, I've not used the Step placements so far.