### PR TITLE
Update selected containers on new placement

### DIFF
--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -1127,6 +1127,7 @@ class StepPlacements(Entity):
         return self._placementslist
 
     def set_placement_list(self, value):
+        containers=set()
         self.get_placement_list()
         for node in self.root.find('output-placements').findall('output-placement'):
             for pair in value:
@@ -1136,7 +1137,8 @@ class StepPlacements(Entity):
                     workset=location[0]
                     well=location[1]
                     if workset and location:
-                        if node.find('location'):
+                        containers.add(workset)
+                        if node.find('location') is not None:
                             cont_el=node.find('location').find('container')
                             cont_el.attrib['uri']=workset.uri
                             cont_el.attrib['limsid']=workset.id
@@ -1147,10 +1149,29 @@ class StepPlacements(Entity):
                             cont_el=ElementTree.SubElement(loc_el, 'container', {'uri': workset.uri, 'limsid' : workset.id})
                             well_el=ElementTree.SubElement(loc_el, 'value')
                             well_el.text=well #not supported in the constructor
-
+        #Handle selected containers
+        sc=self.root.find("selected-containers")
+        sc.clear()
+        for cont in containers:
+            ElementTree.SubElement(sc, 'container', uri=cont.uri)
         self._placementslist=value
 
     placement_list=property(get_placement_list, set_placement_list)
+
+    _selected_containers=None
+    def get_selected_containers(self):
+        _selected_containers=[]
+        if not _selected_containers:
+            self.get()
+            for node in self.root.find('selected-containers').findall('container'):
+                _selected_containers.append(Container(self.lims, uri=node.attrib['uri']))
+
+        return _selected_containers
+
+    selected_containers=property(get_selected_containers)
+
+
+
 
 class StepActions(Entity):
     """Actions associated with a step"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests
+pytest
+mock

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,11 @@ if not version:
 else:
     version = version.decode("utf-8")
 
+try:
+    with open("requirements.txt") as rq:
+        requires=rq.readlines()
+except:
+    requires=["requests"]
 
 setup(name='genologics',
       version=version,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -228,8 +228,8 @@ class TestUdfDictionary(TestCase):
 
 def elements_equal(e1, e2):
     if e1.tag != e2.tag: return False
-    if e1.text != e2.text: return False
-    if e1.tail != e2.tail: return False
+    if e1.text and e2.text and e1.text.strip() != e2.text.strip(): return False
+    if e1.tail and e2.tail and e1.tail.strip() != e2.tail.strip(): return False
     if e1.attrib != e2.attrib: return False
     if len(e1) != len(e2): return False
     return all(elements_equal(c1, c2) for c1, c2 in zip(e1, e2))

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -344,7 +344,7 @@ class TestStepPlacements(TestEntities):
 
 
 
-    def test_get_plactements_list(self):
+    def test_get_placements_list(self):
         s = StepPlacements(uri=self.lims.get_uri('steps', 's1', 'placements'), lims=self.lims)
         with patch('requests.Session.get',return_value=Mock(content = self.original_step_placements_xml, status_code=200)):
             a1 = Artifact(uri='http://testgenologics.com:4040/artifacts/a1', lims=self.lims)
@@ -353,7 +353,7 @@ class TestStepPlacements(TestEntities):
             expected_placements = [[a1,(c1,'1:1')], [a2,(c1,'2:1')]]
             assert s.get_placement_list() == expected_placements
 
-    def test_set_plactements_list(self):
+    def test_set_placements_list(self):
         a1 = Artifact(uri='http://testgenologics.com:4040/artifacts/a1', lims=self.lims)
         a2 = Artifact(uri='http://testgenologics.com:4040/artifacts/a2', lims=self.lims)
         c1 = Container(uri='http://testgenologics.com:4040/containers/c1', lims=self.lims)
@@ -363,9 +363,9 @@ class TestStepPlacements(TestEntities):
         with patch('requests.Session.get',return_value=Mock(content = self.original_step_placements_xml, status_code=200)):
             new_placements = [[a1,(c1,'3:1')], [a2,(c1,'4:1')]]
             s.set_placement_list(new_placements)
-            assert self._tostring(s) == self.modloc_step_placements_xml
+            assert ''.join(self._tostring(s).split()) == ''.join(self.modloc_step_placements_xml.split())
 
-    def test_set_plactements_list_fail(self):
+    def test_set_placements_list_fail(self):
         a1 = Artifact(uri='http://testgenologics.com:4040/artifacts/a1', lims=self.lims)
         a2 = Artifact(uri='http://testgenologics.com:4040/artifacts/a2', lims=self.lims)
         c2 = Container(uri='http://testgenologics.com:4040/containers/c2', lims=self.lims)
@@ -374,4 +374,5 @@ class TestStepPlacements(TestEntities):
         with patch('requests.Session.get',return_value=Mock(content = self.original_step_placements_xml, status_code=200)):
             new_placements = [[a1,(c2,'1:1')], [a2,(c2,'1:1')]]
             s.set_placement_list(new_placements)
-            assert self._tostring(s) == self.modcont_step_placements_xml
+            assert ''.join(self._tostring(s).split()) == ''.join(self.modcont_step_placements_xml.split())
+


### PR DESCRIPTION
This takes care of the last failing test. 
The main issue I have with these tests is that they compare xml strings, and after I play with them through Etree, the whitespaces are not the same, therefore string comparison fails. I couldnt find a quick solution to compare two xml trees, so I compare the strings without spaces. 
If anyone has a better solution that doesnt requires to write an xml comparator, I'm interested.

This doesn't handle "creating a placement from scratch" but I'm really not sure of the necessity of such a thing. Since you cannot create a step from naught with this repo, I don't think it's needed straight away.