### PR TITLE
Work-arounds for python 2.6 support

### DIFF
--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -28,10 +28,16 @@ else:
 
 from .entities import *
 
-# Python 2.6 support work-around
-if not hasattr(ElementTree, 'ParseError'):
+# Python 2.6 support work-arounds
+# - Exception ElementTree.ParseError does not exist
+# - ElementTree.ElementTree.write does not take arg. xml_declaration
+if version_info[:2] < (2,7):
     from xml.parsers import expat
     ElementTree.ParseError = expat.ExpatError
+    p26_write = ElementTree.ElementTree.write
+    ElementTree.ElementTree.write = lambda self, file, encoding, xml_declaration: p26_write(
+                self, file, encoding=encoding
+                )
 
 TIMEOUT = 16
 

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -18,7 +18,7 @@ import requests
 # python 2.7, 3+ compatibility
 from sys import version_info
 
-if version_info.major == 2:
+if version_info[0] == 2:
     from urlparse import urljoin
     from urllib import urlencode
 else:
@@ -27,6 +27,11 @@ else:
 
 
 from .entities import *
+
+# Python 2.6 support work-around
+if not hasattr(ElementTree, 'ParseError'):
+    from xml.parsers import expat
+    ElementTree.ParseError = expat.ExpatError
 
 TIMEOUT = 16
 

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -35,9 +35,11 @@ if version_info[:2] < (2,7):
     from xml.parsers import expat
     ElementTree.ParseError = expat.ExpatError
     p26_write = ElementTree.ElementTree.write
-    ElementTree.ElementTree.write = lambda self, file, encoding, xml_declaration: p26_write(
-                self, file, encoding=encoding
-                )
+    def write_with_xml_declaration(self, file, encoding, xml_declaration):
+        assert xml_declaration is True # Support our use case only 
+        file.write("<?xml version='1.0' encoding='utf-8'?>\n")
+        p26_write(self, file, encoding=encoding)
+    ElementTree.ElementTree.write = write_with_xml_declaration
 
 TIMEOUT = 16
 

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -8,7 +8,7 @@ from genologics.descriptors import StringDescriptor, StringAttributeDescriptor, 
 from genologics.entities import Artifact
 from genologics.lims import Lims
 
-if version_info.major == 2:
+if version_info[0] == 2:
     from mock import Mock
 else:
     from unittest.mock import Mock
@@ -172,7 +172,7 @@ class TestStringDictionaryDescriptor(TestDescriptor):
         sd = self._make_desc(StringDictionaryDescriptor, 'test-subentry')
         res = sd.__get__(self.instance, None)
         assert type(res) == dict
-        self.assertIsNone(res['test-firstkey'])
+        assert res['test-firstkey'] is None
         assert res['test-secondkey'] == 'second value'
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -6,7 +6,7 @@ from genologics.entities import StepActions, Researcher, Artifact, \
     Step, StepPlacements, Container, Stage, ReagentKit, ReagentLot
 from genologics.lims import Lims
 
-if version_info.major == 2:
+if version_info[0] == 2:
     from mock import patch, Mock
 else:
     from unittest.mock import patch, Mock
@@ -158,18 +158,18 @@ class TestStepActions(TestEntities):
 
     def test_escalation(self):
         s = StepActions(uri=self.lims.get_uri('steps', 'step_id', 'actions'), lims=self.lims)
-        with patch('requests.Session.get', return_value=Mock(content=self.step_actions_xml, status_code=200)), \
-             patch('requests.post', return_value=Mock(content=self.dummy_xml, status_code=200)):
-            r = Researcher(uri='http://testgenologics.com:4040/researchers/r1', lims=self.lims)
-            a = Artifact(uri='http://testgenologics.com:4040/artifacts/r1', lims=self.lims)
-            expected_escalation = {
-                'status': 'Reviewed',
-                'author': r,
-                'artifacts': [a], 'request': 'no comments',
-                'answer': 'no comments',
-                'reviewer': r}
+        with patch('requests.Session.get', return_value=Mock(content=self.step_actions_xml, status_code=200)):
+            with patch('requests.post', return_value=Mock(content=self.dummy_xml, status_code=200)):
+                r = Researcher(uri='http://testgenologics.com:4040/researchers/r1', lims=self.lims)
+                a = Artifact(uri='http://testgenologics.com:4040/artifacts/r1', lims=self.lims)
+                expected_escalation = {
+                    'status': 'Reviewed',
+                    'author': r,
+                    'artifacts': [a], 'request': 'no comments',
+                    'answer': 'no comments',
+                    'reviewer': r}
 
-            assert s.escalation == expected_escalation
+                assert s.escalation == expected_escalation
 
     def test_next_actions(self):
         s = StepActions(uri=self.lims.get_uri('steps', 'step_id', 'actions'), lims=self.lims)

--- a/tests/test_lims.py
+++ b/tests/test_lims.py
@@ -4,10 +4,15 @@ from unittest import TestCase
 from requests.exceptions import HTTPError
 
 from genologics.lims import Lims
+try:
+    callable(1)
+except NameError: # callable() doesn't exist in Python 3.0 and 3.1
+    import collections
+    callable = lambda obj: isinstance(obj, collections.Callable)
 
 
 from sys import version_info
-if version_info.major == 2:
+if version_info[0] == 2:
     from mock import patch, Mock
     import __builtin__ as builtins
 else:
@@ -38,7 +43,9 @@ class TestLims(TestCase):
         lims = Lims(self.url, username=self.username, password=self.password)
         r = Mock(content = self.sample_xml, status_code=200)
         pr = lims.parse_response(r)
-        assert isinstance(pr, xml.etree.ElementTree.Element)
+        assert pr is not None
+        assert callable(pr.find)
+        assert hasattr(pr.attrib, '__getitem__')
 
         r = Mock(content = self.error_xml, status_code=400)
         self.assertRaises(HTTPError, lims.parse_response, r)
@@ -48,7 +55,9 @@ class TestLims(TestCase):
     def test_get(self, mocked_instance):
         lims = Lims(self.url, username=self.username, password=self.password)
         r = lims.get('{url}/api/v2/artifacts?sample_name=test_sample'.format(url=self.url))
-        assert isinstance(r, xml.etree.ElementTree.Element)
+        assert r is not None
+        assert callable(r.find)
+        assert hasattr(r.attrib, '__getitem__')
         assert mocked_instance.call_count == 1
         mocked_instance.assert_called_with('http://testgenologics.com:4040/api/v2/artifacts?sample_name=test_sample', timeout=16,
                                   headers={'accept': 'application/xml'}, params={}, auth=('test', 'password'))

--- a/tests/to_rewrite_test_logging.py
+++ b/tests/to_rewrite_test_logging.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from os.path import isdir
 import os
 import sys
-from unittest.case import TestCase
+from unittest import TestCase
 from genologics.epp import EppLogger
 
 file_path = os.path.realpath(__file__)


### PR DESCRIPTION
This pull request fixes some compatibility problems with Python 2.6. 

I had problems that version_info.major is not defined, and that ElementTree.ParseError does not exist on 2.6.