### PR TITLE
Handle errors without <message> element

### DIFF
--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -165,7 +165,9 @@ class Lims(object):
                 node = root.find('message')
                 if node is None:
                     response.raise_for_status()
-                message = "%s: %s" % (response.status_code, node.text)
+                    message = "%s" % (response.status_code)
+                else:
+                    message = "%s: %s" % (response.status_code, node.text)
                 node = root.find('suggested-actions')
                 if node is not None:
                     message += ' ' + node.text

--- a/tests/test_lims.py
+++ b/tests/test_lims.py
@@ -27,6 +27,9 @@ class TestLims(TestCase):
 <exc:exception xmlns:exc="http://genologics.com/ri/exception">
     <message>Generic error message</message>
 </exc:exception>"""
+    error_no_msg_xml = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<exc:exception xmlns:exc="http://genologics.com/ri/exception">
+</exc:exception>"""
 
 
     def test_get_uri(self):
@@ -41,6 +44,9 @@ class TestLims(TestCase):
         assert isinstance(pr, xml.etree.ElementTree.Element)
 
         r = Mock(content = self.error_xml, status_code=400)
+        self.assertRaises(HTTPError, lims.parse_response, r)
+
+        r = Mock(content = self.error_no_msg_xml, status_code=400)
         self.assertRaises(HTTPError, lims.parse_response, r)
 
 


### PR DESCRIPTION
This patch solves a minor problem with error reporting when there is no &lt;message&gt; XML element.