### PR TITLE
Entity setter changes

### DIFF
--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -76,6 +76,10 @@ class StringAttributeDescriptor(TagDescriptor):
         instance.get()
         return instance.root.attrib[self.tag]
 
+    def __set__(self, instance, value):
+        instance.get()
+        instance.root.attrib[self.tag] = value
+
 
 class StringListDescriptor(TagDescriptor):
     """An instance attribute containing a list of strings

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -58,6 +58,7 @@ class StringDescriptor(TagDescriptor):
             return node.text
 
     def __set__(self, instance, value):
+        instance.get()
         node = self.get_node(instance)
         if node is None:
             # create the new tag
@@ -372,6 +373,7 @@ class EntityDescriptor(TagDescriptor):
             return self.klass(instance.lims, uri=node.attrib['uri'])
 
     def __set__(self, instance, value):
+        instance.get()
         node = self.get_node(instance)
         if node is None:
             # create the new tag

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -142,6 +142,17 @@ class TestStringAttributeDescriptor(TestDescriptor):
         sd = self._make_desc(StringAttributeDescriptor, 'name')
         assert sd.__get__(self.instance, None) == "test name"
 
+    def test__set__(self):
+        sd = self._make_desc(StringAttributeDescriptor, 'name')
+        sd.__set__(self.instance, "test name2")
+        assert self.et.attrib['name'] == "test name2"
+
+    def test_create(self):
+        instance_new = Mock(root=ElementTree.Element('test-entry'))
+        bd = self._make_desc(StringAttributeDescriptor, 'name')
+        bd.__set__(instance_new, "test name2")
+        assert instance_new.root.attrib['name'] == "test name2"
+
 
 class TestStringListDescriptor(TestDescriptor):
     def setUp(self):


### PR DESCRIPTION
I've added a call to instance.get() to the some __set__ functions, before they do the modification. This makes sure that the (instance.)root property is set, even if the assignment causing the setter to be called is the first operation on an entity.

I also added a setter for the StringAttributeDescriptor.

Sorry for the sudden flood of pull requests, this will be the last one for a while.