### PR TITLE
do not return a string from an unicode, it confuses Etree

### DIFF
--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -249,9 +249,7 @@ class UdfDictionary(object):
             else:
                 raise NotImplemented("UDF type '%s'" % vtype)
             if not isinstance(value, str):
-                if self._is_string(value):
-                    value=value.encode("UTF-8")
-                else:
+                if not self._is_string(value):
                     value = str(value).encode('UTF-8')
             node.text = value
             break
@@ -278,9 +276,7 @@ class UdfDictionary(object):
                                           type=vtype,
                                           name=key)
             if not isinstance(value, str):
-                if self._is_string(value):
-                    value=value.encode("UTF-8")
-                else:
+                if not self._is_string(value):
                     value = value.encode('UTF-8')
 
             elem.text = value


### PR DESCRIPTION
I think I'm getting to it again. When trying to use unicode values as udfdictionnary values in python2, that's what you need.