### PR TITLE
Step advance

### DIFF
--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -349,6 +349,7 @@ class UdfDictionaryDescriptor(BaseDescriptor):
     def __set__(self, instance, dict_value):
         instance.get()
         udf_dict = UdfDictionary(instance, *self.rootkeys, udt=self._UDT)
+        udf_dict.clear()
         for k in dict_value:
             udf_dict[k] = dict_value[k]
 

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -528,10 +528,17 @@ class InputOutputMapList(BaseDescriptor):
     maps of a Process instance.
     """
 
+    def __init__(self, *args):
+        super(BaseDescriptor, self).__init__()
+        self.rootkeys = args
+
     def __get__(self, instance, cls):
         instance.get()
         self.value = []
-        for node in instance.root.findall('input-output-map'):
+        rootnode = instance.root
+        for rootkey in self.rootkeys:
+            rootnode = rootnode.find(rootkey)
+        for node in rootnode.findall('input-output-map'):
             input = self.get_dict(instance.lims, node.find('input'))
             output = self.get_dict(instance.lims, node.find('output'))
             self.value.append((input, output))

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -346,6 +346,12 @@ class UdfDictionaryDescriptor(BaseDescriptor):
         self.value = UdfDictionary(instance, *self.rootkeys, udt=self._UDT)
         return self.value
 
+    def __set__(self, instance, dict_value):
+        instance.get()
+        udf_dict = UdfDictionary(instance, *self.rootkeys, udt=self._UDT)
+        for k in dict_value:
+            udf_dict[k] = dict_value[k]
+
 
 class UdtDictionaryDescriptor(UdfDictionaryDescriptor):
     """An instance attribute containing a dictionary of UDF values

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -153,9 +153,9 @@ class UdfDictionary(object):
         except:
             return isinstance(value, str)
 
-    def __init__(self, instance, *args, udt=False):
+    def __init__(self, instance, *args, **kwargs):
         self.instance = instance
-        self._udt = udt
+        self._udt = kwargs.pop('udt', False)
         self.rootkeys = args
         self._rootnode = None
         self._update_elems()

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -846,7 +846,7 @@ class StepReagentLots(Entity):
 class StepDetails(Entity):
     """Detail associated with a step"""
 
-    input_output_maps = NestedEntityListDescriptor
+    input_output_maps = InputOutputMapList('input-output-maps')
     udf = UdfDictionaryDescriptor('fields')
     udt = UdtDictionaryDescriptor('fields')
 

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -785,8 +785,7 @@ class StepActions(Entity):
                     self._escalation['artifacts'].extend(art)
         return self._escalation
 
-    @property
-    def next_actions(self):
+    def get_next_actions(self):
         actions = []
         self.get()
         if self.root.find('next-actions') is not None:
@@ -801,6 +800,14 @@ class StepActions(Entity):
                     action['rework-step'] = Step(self.lims, uri=node.attrib.get('rework-step-uri'))
                 actions.append(action)
         return actions
+
+    def set_next_actions(self, actions):
+        for node in self.root.find('next-actions').findall('next-action'):
+            art_uri = node.attrib.get('artifact-uri')
+            action = [action for action in actions if action['artifact'].uri == art_uri][0]
+            if 'action' in action: node.attrib['action'] = action.get('action')
+
+    next_actions = property(get_next_actions, set_next_actions)
 
 
 class ReagentKit(Entity):
@@ -836,6 +843,13 @@ class ReagentLot(Entity):
 class StepReagentLots(Entity):
     reagent_lots = NestedEntityListDescriptor('reagent-lot', ReagentLot, 'reagent-lots')
 
+class StepDetails(Entity):
+    """Detail associated with a step"""
+
+    input_output_maps = NestedEntityListDescriptor
+    udf = UdfDictionaryDescriptor('fields')
+    udt = UdtDictionaryDescriptor('fields')
+
 
 class Step(Entity):
     "Step, as defined by the genologics API."
@@ -843,15 +857,19 @@ class Step(Entity):
     _URI = 'steps'
     _PREFIX = 'stp'
 
+    current_state = StringAttributeDescriptor('current-state')
     _reagent_lots = EntityDescriptor('reagent-lots', StepReagentLots)
     actions       = EntityDescriptor('actions', StepActions)
     placements    = EntityDescriptor('placements', StepPlacements)
+    details       = EntityDescriptor('details', StepDetails)
 
-    # program_status     = EntityDescriptor('program-status',StepProgramStatus)
-    # details            = EntityListDescriptor(nsmap('file:file'), StepDetails)
+    #program_status     = EntityDescriptor('program-status',StepProgramStatus)
 
     def advance(self):
-        self.lims.post("{}/advance".format(self.uri))
+        self.root = self.lims.post(
+            uri="{}/advance".format(self.uri),
+            data=self.lims.tostring(ElementTree.ElementTree(self.root))
+        )
 
     @property
     def reagent_lots(self):


### PR DESCRIPTION
New features in this PR:
 * UdfDictionaryDescriptor and InputOutputMapList can now be nested
 * Add StepDetails which gives access to Step's udf
 * Fix advance which was missing the data field
 * StepActions's next actions can be set by setting the next_actions field 
Next actions is a bit awkward because next_actions returns a mutable but changing them do not update the next actions:
```python
>>> s = Step(l, id='24-56789')
>>> print(s.actions.next_actions[0]['action'])
None
>>> s.actions.next_actions[0]['action'] = 'complete'
>>> print(s.actions.next_actions[0]['action'])
None
```
To set next_actions you need to change the next action then reassign
```python
>>> s = Step(l, id='24-56789')
>>> print(s.actions.next_actions[0]['action'])
None
>>> nas = s.actions.next_actions
>>> nas[0]['action'] = 'complete'
>>> s.actions.next_actions = nas   # <-- This actually set the next_actions
>>> print(s.actions.next_actions[0]['action'])
'complete'
```
To implement this properly I would have to create a new descriptor like the InputOutputMapList but can't be bother at the minute.
I might get around to do it latter