### PR TITLE
Changed 'type' to 'process-type'

### DIFF
--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -1012,7 +1012,7 @@ class ProtocolStep(Entity):
     _TAG = 'step'
 
     name                = StringAttributeDescriptor("name")
-    type                = EntityDescriptor('type', Processtype)
+    type                = EntityDescriptor('process-type', Processtype)
     permittedcontainers = NestedStringListDescriptor('container-type', 'container-types')
     queue_fields        = NestedAttributeListDescriptor('queue-field', 'queue-fields')
     step_fields         = NestedAttributeListDescriptor('step-field', 'step-fields')


### PR DESCRIPTION
Hello,

The XML node for the process type in ProtocolStep should be process-type instead of just type. 

See class: https://www.genologics.com/files/permanent/API/latest/data_protstepcnf.html#element_step

Any feedback would be very welcome, as I'm not familiar with the code enough to know if this will break anything :)

Cheers,
Isaac