### PR TITLE
Check if batch operations are supported before running

### DIFF
--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -199,7 +199,7 @@ class Lims(object):
                     message += ' ' + node.text
             except ElementTree.ParseError:  # some error messages might not follow the xml standard
                 message = response.content
-            raise requests.exceptions.HTTPError(message)
+            raise requests.exceptions.HTTPError(message, response=response)
         return True
 
     def parse_response(self, response, accept_status_codes=[200]):

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -36,7 +36,7 @@ if version_info[:2] < (2,7):
     ElementTree.ParseError = expat.ExpatError
     p26_write = ElementTree.ElementTree.write
     def write_with_xml_declaration(self, file, encoding, xml_declaration):
-        assert xml_declaration is True # Support our use case only 
+        assert xml_declaration is True # Support our use case only
         file.write("<?xml version='1.0' encoding='utf-8'?>\n")
         p26_write(self, file, encoding=encoding)
     ElementTree.ElementTree.write = write_with_xml_declaration
@@ -55,7 +55,7 @@ class Lims(object):
                     For example: https://genologics.scilifelab.se:8443/
         username: The account name of the user to login as.
         password: The password for the user account to login as.
-        version: The optional LIMS API version, by default 'v2' 
+        version: The optional LIMS API version, by default 'v2'
         """
         self.baseuri = baseuri.rstrip('/') + '/'
         self.username = username
@@ -213,7 +213,7 @@ class Lims(object):
     def get_udfs(self, name=None, attach_to_name=None, attach_to_category=None, start_index=None, add_info=False):
         """Get a list of udfs, filtered by keyword arguments.
         name: name of udf
-        attach_to_name: item in the system, to wich the udf is attached, such as 
+        attach_to_name: item in the system, to wich the udf is attached, such as
             Sample, Project, Container, or the name of a process.
         attach_to_category: If 'attach_to_name' is the name of a process, such as 'CaliperGX QC (DNA)',
              then you need to set attach_to_category='ProcessType'. Must not be provided otherwise.
@@ -538,6 +538,11 @@ class Lims(object):
         """
         if not instances:
             return []
+
+        ALLOWED_TAGS = ('artifact', 'container', 'file', 'sample')
+        if instances[0]._TAG not in ALLOWED_TAGS:
+            raise TypeError("Cannot retrieve batch for instances of type '{}'".format(instances[0]._TAG))
+
         root = ElementTree.Element(nsmap('ri:links'))
         needs_request = False
         instance_map = {}
@@ -562,6 +567,10 @@ class Lims(object):
 
         if not instances:
             return
+
+        ALLOWED_TAGS = ('artifact', 'container', 'file', 'sample')
+        if instances[0]._TAG not in ALLOWED_TAGS:
+            raise TypeError("Cannot update batch for instances of type '{}'".format(instances[0]._TAG))
 
         root = None  # XML root element for batch request
 


### PR DESCRIPTION
Only four entities support batch operations (put / update / retrieve): `artifact`, `container`, `file`, and `sample`. If a batch operation is attempted using a different entity (e.g., `project`), the action will throw a request 404 object with no other information about the .

* added a check for supported instance types and modified `get_batch` and `put_batch` to throw a more descriptive `TypeError` when an unsupported instance is specified
* added the `requests.response` object to the `HTTPError` generated when a request fails `validate_response` so that future errors can have more context available for debugging
* some trailing whitespace got eaten by my editor 

Thanks!