### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -1023,7 +1023,7 @@ class Step(Entity):
     def advance(self):
         self.get()
         self.root = self.lims.post(
-            uri="{}/advance".format(self.uri),
+            uri="{0}/advance".format(self.uri),
             data=self.lims.tostring(ElementTree.ElementTree(self.root))
         )
 


### PR DESCRIPTION
Small fix to make step.advance(), python 2.6 compatible.