### PR TITLE
Develop-1159, Rebase from SciLifeLab, then transform to python 3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Genologics'
-copyright = u'2013, Per Kraulis, Johannes Alneberg'
+project = 'Genologics'
+copyright = '2013, Per Kraulis, Johannes Alneberg'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -188,8 +188,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'Genologics.tex', u'Genologics Documentation',
-   u'Per Kraulis, Johannes Alneberg', 'manual'),
+  ('index', 'Genologics.tex', 'Genologics Documentation',
+   'Per Kraulis, Johannes Alneberg', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -218,8 +218,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'genologics', u'Genologics Documentation',
-     [u'Per Kraulis, Johannes Alneberg'], 1)
+    ('index', 'genologics', 'Genologics Documentation',
+     ['Per Kraulis, Johannes Alneberg'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -232,8 +232,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'Genologics', u'Genologics Documentation',
-   u'Per Kraulis, Johannes Alneberg', 'Genologics', 'One line description of project.',
+  ('index', 'Genologics', 'Genologics Documentation',
+   'Per Kraulis, Johannes Alneberg', 'Genologics', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/examples/attach_delivery_report.py
+++ b/examples/attach_delivery_report.py
@@ -20,12 +20,12 @@ lims.check_version()
 
 project = Project(lims, id="P193")
 
-print 'UDFs:'
-pprint(project.udf.items())
+print('UDFs:')
+pprint(list(project.udf.items()))
 
-print 'files:'
+print('files:')
 for file in project.files:
-    print file.content_location
+    print(file.content_location)
 
 project.udf['Delivery Report'] = "http://example.com/delivery_note.pdf"
 project.put()

--- a/examples/epp_script.py
+++ b/examples/epp_script.py
@@ -32,7 +32,7 @@ def main(lims,pid,file):
     io = p.input_output_maps
 
     # Filter them so that only PerInput output artifacts remains
-    io_filtered = filter(lambda (x,y): y['output-generation-type']=='PerInput',io)
+    io_filtered = [x_y for x_y in io if x_y[1]['output-generation-type']=='PerInput']
 
     # Fetch the first input-output artifact pair
     (input,output) = io_filtered[0]

--- a/examples/get_application.py
+++ b/examples/get_application.py
@@ -20,7 +20,7 @@ lims.check_version()
 
 project = Project(lims, id="P193")
 
-print 'UDFs:'
-pprint(project.udf.items())
+print('UDFs:')
+pprint(list(project.udf.items()))
 
-print project.udf['Application']
+print(project.udf['Application'])

--- a/examples/get_artifacts.py
+++ b/examples/get_artifacts.py
@@ -35,15 +35,15 @@ lims.check_version()
 
 name = 'jgr33'
 artifacts = lims.get_artifacts(sample_name=name)
-print len(artifacts), 'artifacts for sample name', name
+print(len(artifacts), 'artifacts for sample name', name)
 
 artifacts = lims.get_batch(artifacts)
 for artifact in artifacts:
-    print artifact, artifact.name, artifact.state
+    print(artifact, artifact.name, artifact.state)
 
-print
+print()
 artifacts = lims.get_artifacts(qc_flag='PASSED')
-print len(artifacts), 'QC PASSED artifacts'
+print(len(artifacts), 'QC PASSED artifacts')
 artifacts = lims.get_batch(artifacts)
 for artifact in artifacts:
-    print artifact, artifact.name, artifact.state
+    print(artifact, artifact.name, artifact.state)

--- a/examples/get_containers.py
+++ b/examples/get_containers.py
@@ -27,28 +27,28 @@ lims.check_version()
 ##     print len(containers), state, 'containers'
 
 containers = lims.get_containers(type='96 well plate')
-print len(containers)
+print(len(containers))
 
 container = containers[2]
-print container, container.occupied_wells
+print(container, container.occupied_wells)
 
 placements = container.get_placements()
-for location, artifact in sorted(placements.iteritems()):
-    print location, artifact.name, id(artifact), repr(artifact), artifact.root
+for location, artifact in sorted(placements.items()):
+    print(location, artifact.name, id(artifact), repr(artifact), artifact.root)
 
 containertype = container.type
-print containertype, containertype.name, containertype.x_dimension, containertype.y_dimension
+print(containertype, containertype.name, containertype.x_dimension, containertype.y_dimension)
 
 
 
 containers = lims.get_containers(type='Illumina Flow Cell',state='Populated')
 for container in containers:
-	print container.name
-	print container.id
-	print container.placements.keys()
+	print(container.name)
+	print(container.id)
+	print(list(container.placements.keys()))
 	arts=lims.get_artifacts(containername=container.name)
 	for art in arts:
-		print art.name
-		print art.type
-		print art.udf.items()
-		print art.parent_process.type.name
+		print(art.name)
+		print(art.type)
+		print(list(art.udf.items()))
+		print(art.parent_process.type.name)

--- a/examples/get_labs.py
+++ b/examples/get_labs.py
@@ -19,21 +19,21 @@ lims.check_version()
 
 # Get the list of all projects.
 labs = lims.get_labs(name='SciLifeLab')
-print len(labs), 'labs in total'
+print(len(labs), 'labs in total')
 for lab in labs:
-    print lab, id(lab), lab.name, lab.uri, lab.id
-    print lab.shipping_address.items()
-    for key, value in lab.udf.items():
-        if isinstance(value, unicode):
+    print(lab, id(lab), lab.name, lab.uri, lab.id)
+    print(list(lab.shipping_address.items()))
+    for key, value in list(lab.udf.items()):
+        if isinstance(value, str):
             value = codecs.encode(value, 'UTF-8')
-        print ' ', key, '=', value
+        print(' ', key, '=', value)
     udt = lab.udt
     if udt:
-        print 'UDT:', udt.udt
-        for key, value in udt.items():
-            if isinstance(value, unicode):
+        print('UDT:', udt.udt)
+        for key, value in list(udt.items()):
+            if isinstance(value, str):
                 value = codecs.encode(value, 'UTF-8')
-            print ' ', key, '=', value
+            print(' ', key, '=', value)
 
 lab = Lab(lims, id='2')
-print lab, id(lab), lab.name, lab.uri, lab.id
+print(lab, id(lab), lab.name, lab.uri, lab.id)

--- a/examples/get_processes.py
+++ b/examples/get_processes.py
@@ -18,12 +18,12 @@ lims.check_version()
 
 # Get the list of all processes.
 processes = lims.get_processes()
-print len(processes), 'processes in total'
+print(len(processes), 'processes in total')
 
 process = Process(lims, id='QCF-PJK-120703-24-1140')
-print process, process.id, process.type, process.type.name
+print(process, process.id, process.type, process.type.name)
 for input, output in process.input_output_maps:
     if input:
-        print 'input:', input.items()
+        print('input:', list(input.items()))
     if output:
-        print 'output:', output.items()
+        print('output:', list(output.items()))

--- a/examples/get_projects.py
+++ b/examples/get_projects.py
@@ -20,32 +20,32 @@ lims.check_version()
 
 # Get the list of all projects.
 projects = lims.get_projects()
-print len(projects), 'projects in total'
+print(len(projects), 'projects in total')
 
 # Get the list of all projects opened since May 30th 2012.
 day = '2012-05-30'
 projects = lims.get_projects(open_date=day)
-print len(projects), 'projects opened since', day
+print(len(projects), 'projects opened since', day)
 
 # Get the project with the specified LIMS id, and print some info.
 project = Project(lims, id='P193')
-print project, project.name, project.open_date, project.close_date
+print(project, project.name, project.open_date, project.close_date)
 
-print '    UDFs:'
-for key, value in project.udf.items():
-    if isinstance(value, unicode):
+print('    UDFs:')
+for key, value in list(project.udf.items()):
+    if isinstance(value, str):
         value = codecs.encode(value, 'UTF-8')
-    print ' ', key, '=', value
+    print(' ', key, '=', value)
 
 udt = project.udt
-print '    UDT:', udt.udt
-for key, value in udt.items():
-    if isinstance(value, unicode):
+print('    UDT:', udt.udt)
+for key, value in list(udt.items()):
+    if isinstance(value, str):
         value = codecs.encode(value, 'UTF-8')
-    print ' ', key, '=', value
+    print(' ', key, '=', value)
 
-print '    files:'
+print('    files:')
 for file in project.files:
-    print file.id
-    print file.content_location
-    print file.original_location
+    print(file.id)
+    print(file.content_location)
+    print(file.original_location)

--- a/examples/get_samples.py
+++ b/examples/get_samples.py
@@ -19,44 +19,44 @@ lims.check_version()
 
 # Get the list of all samples.
 samples = lims.get_samples()
-print len(samples), 'samples in total'
+print(len(samples), 'samples in total')
 
 # Get the list of samples in the project with the LIMS id KLL60.
 project = Project(lims, id='KRA61')
 samples = lims.get_samples(projectlimsid=project.id)
-print len(samples), 'samples in', project
+print(len(samples), 'samples in', project)
 
-print
+print()
 # Get the sample with the LIMS id KRA61A1
 sample = Sample(lims, id='KRA61A1')
-print sample.id, sample.name, sample.date_received, sample.uri,
-for key, value in sample.udf.items():
-    print ' ', key, '=', value
+print(sample.id, sample.name, sample.date_received, sample.uri, end=' ')
+for key, value in list(sample.udf.items()):
+    print(' ', key, '=', value)
 for note in sample.notes:
-    print 'Note', note.uri, note.content
+    print('Note', note.uri, note.content)
 for file in sample.files:
-    print 'File', file.content_location
+    print('File', file.content_location)
 
 # Get the sample with the name 'spruce_a'.
 # Check that it is the sample as the previously obtained sample;
 # not just equal, but exactly the same instance, courtesy of the Lims cache.
 samples = lims.get_samples(name='spruce_a')
-print samples[0].name, samples[0] is sample
+print(samples[0].name, samples[0] is sample)
 
 ## # Get the samples having a UDF Color with values Blue or Orange.
 samples = lims.get_samples(udf={'Color': ['Blue', 'Orange']})
-print len(samples)
+print(len(samples))
 for sample in samples:
-    print sample, sample.name, sample.udf['Color']
+    print(sample, sample.name, sample.udf['Color'])
 
 sample = samples[0]
 
-print
+print()
 # Print the submitter (researcher) for the sample.
 submitter = sample.submitter
-print submitter, submitter.email, submitter.initials, submitter.lab
+print(submitter, submitter.email, submitter.initials, submitter.lab)
 
-print
+print()
 # Print the artifact of the sample.
 artifact = sample.artifact
-print artifact, artifact.state, artifact.type, artifact.qc_flag
+print(artifact, artifact.state, artifact.type, artifact.qc_flag)

--- a/examples/get_samples2.py
+++ b/examples/get_samples2.py
@@ -15,13 +15,13 @@ lims.check_version()
 
 project = Project(lims, id='KRA61')
 samples = lims.get_samples(projectlimsid=project.id)
-print len(samples), 'samples in', project
+print(len(samples), 'samples in', project)
 
 for sample in samples:
-    print sample, sample.name, sample.date_received, sample.artifact
+    print(sample, sample.name, sample.date_received, sample.artifact)
 
 name = 'spruce_a'
 artifacts = lims.get_artifacts(sample_name=name)
-print len(artifacts), 'artifacts for sample', name
+print(len(artifacts), 'artifacts for sample', name)
 for artifact in artifacts:
-    print artifact, artifact.name, artifact.qc_flag
+    print(artifact, artifact.name, artifact.qc_flag)

--- a/examples/set_project_queued.py
+++ b/examples/set_project_queued.py
@@ -20,11 +20,11 @@ lims.check_version()
 
 # Get the project with the LIMS id KLL60, and print some info.
 project = Project(lims, id='KLL60')
-print project, project.name, project.open_date
-print project.udf.items()
+print(project, project.name, project.open_date)
+print(list(project.udf.items()))
 
 d = datetime.date(2012,1,2)
-print d
+print(d)
 
 project.udf['Queued'] = d
 project.put()

--- a/examples/set_sample_name.py
+++ b/examples/set_sample_name.py
@@ -18,14 +18,14 @@ lims.check_version()
 
 # Get the sample with the given LIMS identifier, and output its current name.
 sample = Sample(lims, id='JGR58A21')
-print sample, sample.name
+print(sample, sample.name)
 
 sample.name = 'Joels extra-proper sample-20'
 
 # Set the value of one of the UDFs
 sample.udf['Emmas field 2'] = 5
-for key, value in sample.udf.items():
-    print ' ', key, '=', value
+for key, value in list(sample.udf.items()):
+    print(' ', key, '=', value)
 
 sample.put()
-print 'Updated sample', sample
+print('Updated sample', sample)

--- a/genologics/config.py
+++ b/genologics/config.py
@@ -3,7 +3,7 @@ import sys
 import warnings
 
 try:
-    from ConfigParser import SafeConfigParser
+    from configparser import SafeConfigParser
 except ImportError:
     from configparser import SafeConfigParser
 

--- a/genologics/constants.py
+++ b/genologics/constants.py
@@ -41,7 +41,7 @@ _NSMAP = dict(
         wkfcnf='http://genologics.com/ri/workflowconfiguration'
 )
 
-for prefix, uri in _NSMAP.items():
+for prefix, uri in list(_NSMAP.items()):
     ElementTree._namespace_map[uri] = prefix
 
 _NSPATTERN = re.compile(r'(\{)(.+?)(\})')

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -11,7 +11,7 @@ from genologics.constants import nsmap
 try:
     from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
 except ImportError:
-    from urlparse import urlsplit, urlparse, parse_qs, urlunparse
+    from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
 
 from decimal import Decimal
 import datetime
@@ -157,7 +157,7 @@ class UdfDictionary(object):
 
     def _is_string(self, value):
         try:
-            return isinstance(value, basestring)
+            return isinstance(value, str)
         except:
             return isinstance(value, str)
 
@@ -331,7 +331,7 @@ class UdfDictionary(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         return self.__next__()
 
     def __next__(self):

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -238,8 +238,10 @@ class UdfDictionary(object):
 
     def __setitem__(self, key, value):
         self._lookup[key] = value
+        key_found_in_xml = False
         for node in self._elems:
             if node.attrib['name'] != key: continue
+            key_found_in_xml = True
             vtype = node.attrib['type'].lower()
 
             if value is None:
@@ -278,7 +280,8 @@ class UdfDictionary(object):
                 value = str(value).encode('UTF-8')
             node.text = value
             break
-        else:  # Create new entry; heuristics for type
+
+        if not key_found_in_xml: # Create new entry; heuristics for type
             if self._is_string(value):
                 vtype = '\n' in value and 'Text' or 'String'
             elif isinstance(value, bool):

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -272,13 +272,11 @@ class UdfDictionary(object):
                 value = str(value)
             else:
                 raise NotImplemented("UDF type '%s'" % vtype)
-	    if value is None:
-	        node.text = ''
-	    else:
-		if not isinstance(value, str):
-		    if not self._is_string(value):
-			value = str(value).encode('UTF-8')
-		node.text = value
+            if value is None:
+                value = ''
+            elif not isinstance(value, str):
+                value = str(value).encode('UTF-8')
+            node.text = value
             break
         else:  # Create new entry; heuristics for type
             if self._is_string(value):

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -619,7 +619,7 @@ class ReagentLabelList(BaseDescriptor):
         if not nodes:
             root = instance.root
             for value in values:
-                rl_node = ElementTree.SubElement(root, 'reagent-label', name=value)
+                ElementTree.SubElement(root, 'reagent-label', name=value)
 
         elif len(values) != len(nodes):
             raise ValueError("Mismatching number of reagent labels")

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -74,6 +74,13 @@ class StringAttributeDescriptor(TagDescriptor):
     """
 
     def __get__(self, instance, cls):
+        # Skip loading the instance if we have information in the extra dictionary. This
+        # allows faster loading when the data is available in an overview page. An example is
+        # that names of Stages and Protocols is available in the details page for Workflows.
+
+        # If we have loaded the details for this entity (instance.root is not None), we always use that.
+        if instance.extra is not None and instance.root is None and self.tag in instance.extra:
+            return instance.extra[self.tag]
         instance.get()
         return instance.root.attrib[self.tag]
 
@@ -518,22 +525,26 @@ class NestedStringListDescriptor(StringListDescriptor):
 class NestedEntityListDescriptor(EntityListDescriptor):
     """same as EntityListDescriptor, but works on nested elements"""
 
-    def __init__(self, tag, klass, *args):
+    def __init__(self, tag, klass, rootkey=None, extra=[]):
         super(EntityListDescriptor, self).__init__(tag, klass)
         self.klass = klass
         self.tag = tag
-        self.rootkeys = args
+        self.rootkey = rootkey
+        self.extra_meta = extra
 
     def __get__(self, instance, cls):
         instance.get()
         result = []
         rootnode = instance.root
-        for rootkey in self.rootkeys:
-            rootnode = rootnode.find(rootkey)
+        if self.rootkey:
+            rootnode = rootnode.find(self.rootkey)
         for node in rootnode.findall(self.tag):
-            result.append(self.klass(instance.lims, uri=node.attrib['uri']))
-
+            # NOTE: The name should correspond to the name on the object, not necessarily the same
+            # as the name of the attribute.
+            extra = {extra_name: node.attrib[extra_name] for extra_name in self.extra_meta}
+            result.append(self.klass(instance.lims, uri=node.attrib['uri'], extra=extra))
         return result
+
 
 class MultiPageNestedEntityListDescriptor(EntityListDescriptor):
     """same as NestedEntityListDescriptor, but works on multiple pages, for Queues"""

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -613,6 +613,20 @@ class ReagentLabelList(BaseDescriptor):
                 pass
         return self.value
 
+    def __set__(self, instance, values):
+        instance.get()
+        nodes = instance.root.findall('reagent-label')
+        if not nodes:
+            root = instance.root
+            for value in values:
+                rl_node = ElementTree.SubElement(root, 'reagent-label', name=value)
+
+        elif len(values) != len(nodes):
+            raise ValueError("Mismatching number of reagent labels")
+        else:
+            for node, value in zip(nodes, values):
+                node.attrib['name'] = value
+
 
 class OutputReagentList(BaseDescriptor):
     """

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -272,10 +272,13 @@ class UdfDictionary(object):
                 value = str(value)
             else:
                 raise NotImplemented("UDF type '%s'" % vtype)
-            if not isinstance(value, str):
-                if not self._is_string(value):
-                    value = str(value).encode('UTF-8')
-            node.text = value
+	    if value is None:
+	        node.text = ''
+	    else:
+		if not isinstance(value, str):
+		    if not self._is_string(value):
+			value = str(value).encode('UTF-8')
+		node.text = value
             break
         else:  # Create new entry; heuristics for type
             if self._is_string(value):

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -510,7 +510,7 @@ class Sample(Entity):
         """
         Creates a request for creating a single sample object
         """
-        udfs = kwargs.pop("udfs", list())
+        udfs = kwargs.pop("udfs", dict())
         if not isinstance(container, Container):
             raise TypeError('%s is not of type Container' % container)
         instance = super(Sample, cls)._create(lims, creation_tag='samplecreation', **kwargs)

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -18,7 +18,7 @@ from genologics.descriptors import StringDescriptor, StringDictionaryDescriptor,
 try:
     from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
 except ImportError:
-    from urlparse import urlsplit, urlparse, parse_qs, urlunparse
+    from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
 
 from xml.etree import ElementTree
 
@@ -61,11 +61,11 @@ class SampleHistory:
         #    logger.info(value[1]+"->"+value[0].id+"->"+key)
         logger.info("\nHistory :\n\n")
         logger.info("Input\tProcess\tProcess info")
-        for key, dict in self.history.items():
+        for key, dict in list(self.history.items()):
             logger.info(key)
-            for key2, dict2 in dict.items():
+            for key2, dict2 in list(dict.items()):
                 logger.info("\t{}".format(key2))
-                for key, value in dict2.items():
+                for key, value in list(dict2.items()):
                     logger.info("\t\t{0}->{1}".format(key, (value if value is not None else "None")))
         logger.info("\nHistory List")
         for art in self.history_list:
@@ -521,7 +521,7 @@ class Sample(Entity):
 
         # NOTE: This is a quick fix. I assume that it must be possible to initialize samples
         # with UDFs
-        for key, value in udfs.items():
+        for key, value in list(udfs.items()):
             attrib = {
                 "name": key,
                 "xmlns:udf": "http://genologics.com/ri/userdefined",

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -461,18 +461,31 @@ class Sample(Entity):
 
 
     @classmethod
-    def create(cls, lims, container, position, udfs=None, **kwargs):
-        """Create an instance of Sample from attributes then post it to the LIMS"""
-        if udfs is None:
-            udfs = {}
+    def create(cls, lims, container, position, **kwargs):
+        """Create an instance of Sample from attributes then post it to the LIMS
+
+        Udfs can be sent in with the kwarg `udfs`. It should be a dictionary-like.
+        """
         if not isinstance(container, Container):
             raise TypeError('%s is not of type Container'%container)
-        instance = super(Sample, cls)._create(lims, creation_tag='samplecreation',udfs=udfs, **kwargs)
+        udfs = kwargs.pop("udfs", None)
+        instance = super(Sample, cls)._create(lims, creation_tag='samplecreation', **kwargs)
 
         location = ElementTree.SubElement(instance.root, 'location')
         ElementTree.SubElement(location, 'container', dict(uri=container.uri))
         position_element = ElementTree.SubElement(location, 'value')
         position_element.text = position
+
+        # NOTE: This is a quick fix. I assume that it must be possible to initialize samples
+        # with UDFs
+        for key, value in udfs.items():
+            attrib = {
+                "name": key,
+                "xmlns:udf": "http://genologics.com/ri/userdefined",
+            }
+            udf = ElementTree.SubElement(instance.root, 'udf:field', attrib=attrib)
+            udf.text = value
+
         data = lims.tostring(ElementTree.ElementTree(instance.root))
         instance.root = lims.post(uri=lims.get_uri(cls._URI), data=data)
         instance._uri = instance.root.attrib['uri']

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -446,7 +446,6 @@ class Project(Entity):
     udt          = UdtDictionaryDescriptor()
     files        = EntityListDescriptor(nsmap('file:file'), File)
     externalids  = ExternalidListDescriptor()
-    instrument = EntityDescriptor('instrument', Instrument)
     # permissions XXX
 
 
@@ -609,7 +608,7 @@ class Process(Entity):
     udt               = UdtDictionaryDescriptor()
     files             = EntityListDescriptor(nsmap('file:file'), File)
     process_parameter = StringDescriptor('process-parameter')
-    intrument = StringDescriptor('instrument')
+    instrument = EntityDescriptor('instrument', Instrument)
 
     # process_parameters XXX
 

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -238,7 +238,7 @@ class Entity(object):
     _URI = None
     _PREFIX = None
 
-    def __new__(cls, lims, uri=None, id=None, _create_new=False):
+    def __new__(cls, lims, uri=None, id=None, _create_new=False, extra=None):
         if not uri:
             if id:
                 uri = lims.get_uri(cls._URI, id)
@@ -252,7 +252,7 @@ class Entity(object):
         except KeyError:
             return object.__new__(cls)
 
-    def __init__(self, lims, uri=None, id=None, _create_new=False):
+    def __init__(self, lims, uri=None, id=None, _create_new=False, extra=None):
         assert uri or id or _create_new
         if not _create_new:
             if hasattr(self, 'lims'): return
@@ -263,6 +263,7 @@ class Entity(object):
         self.lims = lims
         self._uri = uri
         self.root = None
+        self.extra = extra
 
     def __str__(self):
         return "%s(%s)" % (self.__class__.__name__, self.id)
@@ -1077,6 +1078,7 @@ class Protocol(Entity):
     _URI = 'configuration/protocols'
     _TAG = 'protocol'
 
+    name       = StringAttributeDescriptor('name')
     steps      = NestedEntityListDescriptor('step', ProtocolStep, 'steps')
     properties = NestedAttributeListDescriptor('protocol-property', 'protocol-properties')
 
@@ -1109,8 +1111,8 @@ class Workflow(Entity):
 
     name      = StringAttributeDescriptor("name")
     status    = StringAttributeDescriptor("status")
-    protocols = NestedEntityListDescriptor('protocol', Protocol, 'protocols')
-    stages    = NestedEntityListDescriptor('stage', Stage, 'stages')
+    protocols = NestedEntityListDescriptor('protocol', Protocol, 'protocols', extra=["name"])
+    stages    = NestedEntityListDescriptor('stage', Stage, 'stages', extra=["name"])
 
 
 class ReagentType(Entity):

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -420,6 +420,16 @@ class File(Entity):
     is_published      = BooleanDescriptor('is-published')
 
 
+class Instrument(Entity):
+    "Instrument"
+    _URI = 'instruments'
+    _PREFIX = 'inst'
+    name = StringDescriptor('name')
+    type = StringDescriptor('type')
+    serial_number = StringDescriptor('serial-number')
+    archived = BooleanDescriptor('archived')
+
+
 class Project(Entity):
     "Project concerning a number of samples; associated with a researcher."
 
@@ -436,6 +446,7 @@ class Project(Entity):
     udt          = UdtDictionaryDescriptor()
     files        = EntityListDescriptor(nsmap('file:file'), File)
     externalids  = ExternalidListDescriptor()
+    instrument = EntityDescriptor('instrument', Instrument)
     # permissions XXX
 
 
@@ -598,7 +609,7 @@ class Process(Entity):
     udt               = UdtDictionaryDescriptor()
     files             = EntityListDescriptor(nsmap('file:file'), File)
     process_parameter = StringDescriptor('process-parameter')
-    instrument        = EntityDescriptor('instrument', Instrument)
+    intrument = StringDescriptor('instrument')
 
     # process_parameters XXX
 

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -23,6 +23,7 @@ except ImportError:
 from xml.etree import ElementTree
 
 import logging
+import copy
 
 logger = logging.getLogger(__name__)
 
@@ -476,11 +477,43 @@ class Sample(Entity):
 
         Udfs can be sent in with the kwarg `udfs`. It should be a dictionary-like.
         """
-        if not isinstance(container, Container):
-            raise TypeError('%s is not of type Container'%container)
-        udfs = kwargs.pop("udfs", None)
-        instance = super(Sample, cls)._create(lims, creation_tag='samplecreation', **kwargs)
+        instance = cls.create_in_memory_instance(lims, container, position, **kwargs)
+        data = lims.tostring(ElementTree.ElementTree(instance.root))
+        instance.root = lims.post(uri=lims.get_uri(cls._URI), data=data)
+        instance._uri = instance.root.attrib['uri']
+        return instance
 
+    @classmethod
+    def batch_create(cls, lims, in_memory_instances):
+        """
+        Batch creates the samples. The list in_memory_instances is created by calls to
+        `Sample.create_in_memory_instance`
+        """
+        # Create a batch request from all in_memory_instances:
+        batch = ElementTree.Element(nsmap(cls._PREFIX + ':details'))
+
+        for instance in in_memory_instances:
+            element = copy.deepcopy(instance.root)
+            batch.append(element)
+
+        data = lims.tostring(ElementTree.ElementTree(batch))
+        response = lims.post(uri=lims.get_uri('samples/batch/create'), data=data)
+
+        ret = list()
+        for entry in response:
+            uri = entry.attrib['uri']
+            ret.append(Sample(lims=lims, uri=uri))
+        return ret
+
+    @classmethod
+    def create_in_memory_instance(cls, lims, container, position, **kwargs):
+        """
+        Creates a request for creating a single sample object
+        """
+        udfs = kwargs.pop("udfs", list())
+        if not isinstance(container, Container):
+            raise TypeError('%s is not of type Container' % container)
+        instance = super(Sample, cls)._create(lims, creation_tag='samplecreation', **kwargs)
         location = ElementTree.SubElement(instance.root, 'location')
         ElementTree.SubElement(location, 'container', dict(uri=container.uri))
         position_element = ElementTree.SubElement(location, 'value')
@@ -495,10 +528,6 @@ class Sample(Entity):
             }
             udf = ElementTree.SubElement(instance.root, 'udf:field', attrib=attrib)
             udf.text = value
-
-        data = lims.tostring(ElementTree.ElementTree(instance.root))
-        instance.root = lims.post(uri=lims.get_uri(cls._URI), data=data)
-        instance._uri = instance.root.attrib['uri']
         return instance
 
 
@@ -556,8 +585,7 @@ class Udfconfig(Entity):
     first_preset_is_default_value = BooleanDescriptor('first-preset-is-default-value')
     show_in_tables                = BooleanDescriptor('show-in-tables')
     is_editable                   = BooleanDescriptor('is-editable')
-    is_required                   = BooleanDescriptor('is-required')
-    is_deviation                  = BooleanDescriptor('is-deviation') 
+    is_deviation                  = BooleanDescriptor('is-deviation')
     is_controlled_vocabulary      = BooleanDescriptor('is-controlled-vocabulary')
     presets                       = StringListDescriptor('preset')
 
@@ -676,8 +704,8 @@ class Process(Entity):
         return [a for a in artifacts if a.output_type == 'ResultFile']
 
     def analytes(self):
-        """Retreving the output Analytes of the process, if existing. 
-        If the process is not producing any output analytes, the input 
+        """Retreving the output Analytes of the process, if existing.
+        If the process is not producing any output analytes, the input
         analytes are returned. Input/Output is returned as a information string.
         Makes aggregate processes and normal processes look the same."""
         info = 'Output'

--- a/genologics/epp.py
+++ b/genologics/epp.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 """Contains useful and reusable code for EPP scripts.
 
 Classes, methods and exceptions.

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -19,8 +19,8 @@ import requests
 from sys import version_info
 
 if version_info[0] == 2:
-    from urlparse import urljoin
-    from urllib import urlencode
+    from urllib.parse import urljoin
+    from urllib.parse import urlencode
 else:
     from urllib.parse import urljoin
     from urllib.parse import urlencode
@@ -489,7 +489,7 @@ class Lims(object):
     def _get_params(self, **kwargs):
         "Convert keyword arguments to a kwargs dictionary."
         result = dict()
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             if value is None: continue
             result[key.replace('_', '-')] = value
         return result
@@ -497,11 +497,11 @@ class Lims(object):
     def _get_params_udf(self, udf=dict(), udtname=None, udt=dict()):
         "Convert UDF-ish arguments to a params dictionary."
         result = dict()
-        for key, value in udf.items():
+        for key, value in list(udf.items()):
             result["udf.%s" % key] = value
         if udtname is not None:
             result['udt.name'] = udtname
-        for key, value in udt.items():
+        for key, value in list(udt.items()):
             result["udt.%s" % key] = value
         return result
 
@@ -564,7 +564,7 @@ class Lims(object):
             for node in root.getchildren():
                 instance = instance_map[node.attrib['limsid']]
                 instance.root = node
-        return instance_map.values()
+        return list(instance_map.values())
 
     def put_batch(self, instances):
         """Update multiple instances using a single batch request."""

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -234,6 +234,10 @@ class Lims(object):
                                   start_index=start_index)
         return self._get_instances(ReagentType, params=params)
 
+    def get_containertypes(self, name=None):
+        params = self._get_params(name=name)
+        return self._get_instances(Containertype, params=params)
+
     def get_labs(self, name=None, last_modified=None,
                  udf=dict(), udtname=None, udt=dict(), start_index=None, add_info=False):
         """Get a list of labs, filtered by keyword arguments.

--- a/genologics/test_utils.py
+++ b/genologics/test_utils.py
@@ -26,7 +26,7 @@ def patched_get(*args, **kwargs):
         uri=kwargs['uri']
     else:
         for arg in args:
-            if isinstance(arg, str) or isinstance(arg, unicode):
+            if isinstance(arg, str) or isinstance(arg, str):
                 uri = arg
     if 'params' in kwargs:
         params=kwargs['params']
@@ -48,7 +48,7 @@ def dump_source_xml(lims):
     to be used with patched_get"""
     final_string = []
     final_string.append('{')
-    for k, v in lims.cache.iteritems():
+    for k, v in lims.cache.items():
         final_string.append("'{0}':".format(k))
         v.get()
         final_string.append('"""{0}""",'.format(v.xml().replace('\n', "\n")))

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -257,10 +257,10 @@ class TestUdfDictionary(TestCase):
 
     def test___setitem__unicode(self):
         assert self._get_udf_value(self.dict1, 'test') == 'stuff'
-        self.dict1.__setitem__('test', u'unicode')
+        self.dict1.__setitem__('test', 'unicode')
         assert self._get_udf_value(self.dict1, 'test') == 'unicode'
 
-        self.dict1.__setitem__(u'test', 'unicode2')
+        self.dict1.__setitem__('test', 'unicode2')
         assert self._get_udf_value(self.dict1, 'test') == 'unicode2'
 
     def test___delitem__(self):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -169,19 +169,19 @@ class TestEntities(TestCase):
 
 def elements_equal(e1, e2):
     if e1.tag != e2.tag:
-        print('Tag: %s != %s' % (e1.tag, e2.tag))
+        print(('Tag: %s != %s' % (e1.tag, e2.tag)))
         return False
     if e1.text and e2.text and e1.text.strip() != e2.text.strip():
-        print('Text: %s != %s' % (e1.text.strip(), e2.text.strip()))
+        print(('Text: %s != %s' % (e1.text.strip(), e2.text.strip())))
         return False
     if e1.tail and e2.tail and e1.tail.strip() != e2.tail.strip():
-        print('Tail: %s != %s' % (e1.tail.strip(), e2.tail.strip()))
+        print(('Tail: %s != %s' % (e1.tail.strip(), e2.tail.strip())))
         return False
     if e1.attrib != e2.attrib:
-        print('Attrib: %s != %s' % (e1.attrib, e2.attrib))
+        print(('Attrib: %s != %s' % (e1.attrib, e2.attrib)))
         return False
     if len(e1) != len(e2):
-        print('length %s (%s) != length (%s) ' % (e1.tag, len(e1), e2.tag, len(e2)))
+        print(('length %s (%s) != length (%s) ' % (e1.tag, len(e1), e2.tag, len(e2))))
         return False
     return all(
         elements_equal(c1, c2) for c1, c2 in zip(sorted(e1, key=lambda x: x.tag), sorted(e2, key=lambda x: x.tag)))

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -31,7 +31,7 @@ class TestExample(TestCase):
     def test_project_example(self):
         with patch("genologics.lims.Lims.get", side_effect=test_utils.patched_get):
             pj = Project(self.lims, id='BLA1')
-            self.assertEquals(pj.name, 'Test')
+            self.assertEqual(pj.name, 'Test')
 
 
 if __name__ == '__main__':

--- a/tests/test_lims.py
+++ b/tests/test_lims.py
@@ -14,7 +14,7 @@ except NameError: # callable() doesn't exist in Python 3.0 and 3.1
 from sys import version_info
 if version_info[0] == 2:
     from mock import patch, Mock
-    import __builtin__ as builtins
+    import builtins as builtins
 else:
     from unittest.mock import patch, Mock
     import builtins

--- a/tests/to_rewrite_test_logging.py
+++ b/tests/to_rewrite_test_logging.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 from os.path import isdir
 import os


### PR DESCRIPTION
First, I did a rebase from the main repo at SciLifelab, then i transformed to python 3 by the tool 2to3. Although I believe that stockholm is already running python3, there were still some lines that were transformed by 2to3. Probably, these lines of code is not used anymore. 

There was a real need for us to move to python 3, because the fact that genologics is the name of the package as well as the first module caused problems in python 2. 

As a consequence, transforming to python3 makes the automated tests working once again. 

Risk analyzis:
Since this PR contains a rebase of a shared repository, care must be taken so that all that work on genologics repo henceforth first fetch the latest version. 

Details:
We had a chat about the hard-to-penetrate code in descriptors.__setitem__ the other day. Now, I have clarified that code somewhat, and also made it pass all automated tests. However, the code in __setitem__, as I believe, cannot perform the task it claims to do, namely to set udfs that were not included in the original fetch. As I recall, we discovered that at the beginning of our work in clarity-ext, and started to use .force() instead. 