### PR TITLE
Remove deprecated function and update code to be compatible with py3.9

### DIFF
--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -105,7 +105,7 @@ class StringDictionaryDescriptor(TagDescriptor):
         result = dict()
         node = instance.root.find(self.tag)
         if node is not None:
-            for node2 in node.getchildren():
+            for node2 in list(node):
                 result[node2.tag] = node2.text
         return result
 
@@ -194,7 +194,7 @@ class UdfDictionary(object):
                 self._elems = elem.findall(nsmap('udf:field'))
         else:
             tag = nsmap('udf:field')
-            for elem in self.rootnode.getchildren():
+            for elem in list(self.rootnode):
                 if elem.tag == tag:
                     self._elems.append(elem)
 

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -557,7 +557,7 @@ class Lims(object):
             uri = self.get_uri(instance.__class__._URI, 'batch/retrieve')
             data = self.tostring(ElementTree.ElementTree(root))
             root = self.post(uri, data)
-            for node in root.getchildren():
+            for node in list(root):
                 instance = instance_map[node.attrib['limsid']]
                 instance.root = node
         return list(instance_map.values())


### PR DESCRIPTION
Element.getchildren has been deprecated in py3.2 and completely removed in py3.9. This applies the suggested fix.
https://bugs.python.org/issue29209